### PR TITLE
Secrets to credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Introduction goes here.
   bundle exec rails g spree_homepage:install
   ```
 
+5. Open config/credentials.yml.enc by running `EDITOR="nano" bin/rails credentials:edit` (change `EDITOR` if necessary) inside Spree. Insert the following credentials:
+
+```
+instagram_client_id: <client_id_here>
+instagram_client_secret: <secret_here>
+```
+
+Running `bin/rails credentials:edit` will create an encrypted configuration file and place the key inside config/master.key (ignored by Git). In production, the key is provided using the `RAILS_MASTER_KEY` environment variable.
+
 4. Restart your server
 
   If your server was running, restart it so that it can find the assets properly.

--- a/config/initializers/instagram.rb
+++ b/config/initializers/instagram.rb
@@ -1,4 +1,4 @@
 Instagram.configure do |config|
-  config.client_id = Rails.application.secrets.instagram_client_id
-  config.client_secret = Rails.application.secrets.instagram_client_secret
+  config.client_id = Rails.application.credentials.instagram_client_id
+  config.client_secret = Rails.application.credentials.instagram_client_secret
 end


### PR DESCRIPTION
We're encrypting credentials and therefore would like to move Instagram creds to credentials from secrets. Details: https://www.engineyard.com/blog/rails-encrypted-credentials-on-rails-5.2